### PR TITLE
Update api_operation.md

### DIFF
--- a/declarative_comments_format/api_operation.md
+++ b/declarative_comments_format/api_operation.md
@@ -12,7 +12,7 @@
 | security           | [Security](#security) to each API operation.                                                                               |
 | success            | Success response that separated by spaces. `return code`,`{param type}`,`data type`,`comment`                              |
 | failure            | Failure response that separated by spaces. `return code`,`{param type}`,`data type`,`comment`                              |
-| router             | Failure response that separated by spaces. `path`,`[httpMethod]`                                                           |
+| router             | Method call URI `path`,`[httpMethod]`                                                                                      |
 
 ## Example
 


### PR DESCRIPTION
Fixed API annotation `router` description. Seems it was copypasted from `failure ` field